### PR TITLE
BugFix, New Searches No Longer Append to Previous Searches

### DIFF
--- a/Assets/JS/script.js
+++ b/Assets/JS/script.js
@@ -29,6 +29,9 @@ if (getComputedStyle(wrapperDiv).display !== "none") {
 document.getElementById('searchBtn').addEventListener('click', function(event) {
     event.preventDefault(); // Prevents the form from submitting and also refreshing the page
 
+    // Clears the generated HTML whenever clicked. Functions to refresh the suggestions on a new search.
+    document.getElementById('recommendedMovies').innerHTML = '';
+
     // Hide the landing-page section
     document.getElementById('landing-page').style.display = 'none';
 


### PR DESCRIPTION
This PR is a fixes a bug with the Dynamic HTML added by JS.

On pressing the "searchBtn" again, generated suggestions would append to the bottom of previously generated suggestions.

The Dynamic HTML is now cleared initially when the "searchBtn" is clicked, clearing all previously loaded suggestions before generating new ones.

NOTE: This is for the "Stop the Doom Scroll" button on the search form only. 
Once functionality has been added to the "Generate More Suggestions" button, this may need to be altered for both to function independently.